### PR TITLE
Add wrapper #ifndef ssize_t for compile it inside vcpkg

### DIFF
--- a/SMP/gnutls/gnutls.h
+++ b/SMP/gnutls/gnutls.h
@@ -39,9 +39,9 @@
 /* Get ssize_t. */
 #ifdef _MSC_VER
 #  include <BaseTsd.h>
-#ifndef ssize_t
+#  ifndef ssize_t
 typedef SSIZE_T ssize_t;
-#endif
+#  endif
 #  include <sys/types.h>
 #else
 #  include <sys/types.h>

--- a/SMP/gnutls/gnutls.h
+++ b/SMP/gnutls/gnutls.h
@@ -39,7 +39,9 @@
 /* Get ssize_t. */
 #ifdef _MSC_VER
 #  include <BaseTsd.h>
+#ifndef ssize_t
 typedef SSIZE_T ssize_t;
+#endif
 #  include <sys/types.h>
 #else
 #  include <sys/types.h>


### PR DESCRIPTION
<!--- Provide a general summary of the enhancement in the Title above -->
I added #ifndef ssize_t wrapper, for compile the gnu tls with curl with vcpkg

## Context
<!--- Provide a more detailed introduction to the enhancement itself, and why you consider it to be useful -->
without this wrapper I get an error on this line:
https://github.com/ShiftMediaProject/gnutls/blob/master/SMP/gnutls/gnutls.h#L42
```
C:\src\vcpkg\installed\x64-windows\include\gnutls/gnutls.h(42): error C2628: 'SSIZE_T' followed by '__int64' is illegal (did you forget a ';'?)
```


## Current and Suggested Behavior
<!--- Tell us what currently happens and then what this enhancement changes -->
This wrapper suggested here:
https://github.com/ShiftMediaProject/gnutls/issues/13#issuecomment-2240943591

## Steps to Explain Enhancement
<!--- Provide an unambiguous set of steps to reproduce this bug -->
1.
2.
3.
4.

## Your Test Environment
<!--- Include as many relevant details about the environment you tested in -->
* Version Used: 3.8.3
* Operating System and Version(s): windows 11
* Compiler and version(s): 
*  Visual Studio 2022 Prompt v17.5.3
* CL:  C/C++ Optimizing Compiler Version 19.35.32216.1 for x64