### PR TITLE
Fix types of gnutls_ocsp_resp_get_single according curl compilation

### DIFF
--- a/lib/includes/gnutls/ocsp.h
+++ b/lib/includes/gnutls/ocsp.h
@@ -224,9 +224,9 @@ int gnutls_ocsp_resp_get_single(gnutls_ocsp_resp_const_t resp, unsigned indx,
 				gnutls_datum_t *issuer_name_hash,
 				gnutls_datum_t *issuer_key_hash,
 				gnutls_datum_t *serial_number,
-				unsigned int *cert_status, time_t *this_update,
+				gnutls_ocsp_cert_status_t *cert_status, time_t *this_update,
 				time_t *next_update, time_t *revocation_time,
-				unsigned int *revocation_reason);
+				gnutls_x509_crl_reason_t *revocation_reason);
 int gnutls_ocsp_resp_get_extension(gnutls_ocsp_resp_const_t resp, unsigned indx,
 				   gnutls_datum_t *oid, unsigned int *critical,
 				   gnutls_datum_t *data);

--- a/lib/x509/ocsp.c
+++ b/lib/x509/ocsp.c
@@ -1433,9 +1433,9 @@ int gnutls_ocsp_resp_get_single(gnutls_ocsp_resp_const_t resp, unsigned indx,
 				gnutls_datum_t *issuer_name_hash,
 				gnutls_datum_t *issuer_key_hash,
 				gnutls_datum_t *serial_number,
-				unsigned int *cert_status, time_t *this_update,
+				gnutls_ocsp_cert_status_t *cert_status, time_t *this_update,
 				time_t *next_update, time_t *revocation_time,
-				unsigned int *revocation_reason)
+				gnutls_x509_crl_reason_t *revocation_reason)
 {
 	char name[MAX_NAME_SIZE];
 	int ret, result;


### PR DESCRIPTION
When compile shifmedia-gnutls with curl, it give a warning on gnutls_ocsp_resp_get_single that it not use the correct types.
Curl usually compile their code without warning, then these warning transfer to errors.  

https://github.com/curl/curl/blob/master/lib/vtls/gtls.c#L1344

from the ci:
https://github.com/talregev/curl/actions/runs/10070483253/job/27839082374?pr=12
```
D:\a\curl\curl\lib\vtls\gtls.c(1345,41): error C2220: the following warning is treated as an error [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\gtls.c(1345,41): warning C4133: 'function': incompatible types - from 'gnutls_ocsp_cert_status_t *' to 'unsigned int *' [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\gtls.c(1345,68): warning C4133: 'function': incompatible types - from 'gnutls_x509_crl_reason_t *' to 'unsigned int *' [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
```

<!--- Provide a general summary of the enhancement in the Title above -->

## Context
<!--- Provide a more detailed introduction to the enhancement itself, and why you consider it to be useful -->

## Current and Suggested Behavior
<!--- Tell us what currently happens and then what this enhancement changes -->

## Steps to Explain Enhancement
<!--- Provide an unambiguous set of steps to reproduce this bug -->
1.
2.
3.
4.

## Your Test Environment
<!--- Include as many relevant details about the environment you tested in -->
* Version Used:
* Operating System and Version(s):
* Compiler and version(s):